### PR TITLE
Update PackageInfo.g, set new homepage at GitHub

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -2,9 +2,8 @@ SetPackageInfo( rec(
 PackageName := "rig",
 Subtitle := "Racks in GAP",
 Version := "1",
-Date := "24/05/2014",
-ArchiveURL := "http://code.google.com/p/rig/",
-ArchiveFormats := ".zoo",
+Date := "24/05/2014", # dd/mm/yyyy format
+
 Persons := [
   rec( 
     LastName      := "Vendramin",
@@ -23,22 +22,27 @@ Persons := [
 ],
 
 Status := "deposited",
-README_URL := 
-  "http://www.math.rwth-aachen.de/~Greg.Gamble/Example/README.example",
-PackageInfoURL := 
-  "http://www.math.rwth-aachen.de/~Greg.Gamble/Example/PackageInfo.g",
+
+PackageWWWHome  := "https://gap-packages.github.io/rig/",
+README_URL      := Concatenation( ~.PackageWWWHome, "README.md" ),
+PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+SourceRepository := rec(
+    Type := "git",
+    URL := "https://github.com/gap-packages/rig",
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/v", ~.Version,
+                                 "/rig-", ~.Version ),
+ArchiveFormats := ".tar.gz",
 
 AbstractHTML := 
   "The <span class=\"pkgname\">Example</span> package, as its name suggests, \
    is an example of how to create a <span class=\"pkgname\">GAP</span> \
    package. It has little functionality except for being a package",
 
-PackageWWWHome := "http://www.math.rwth-aachen.de/~Greg.Gamble/Example",
-               
 PackageDoc := rec(
   BookName  := "rig",
-  # format/extension can be one of .zoo, .tar.gz, .tar.bz2, -win.zip
-#  Archive := "http://www.math.rwth-aachen.de/~Greg.Gamble/Example/exampledoc-2.0.zoo",
   ArchiveURLSubset := ["doc", "htm"],
   HTMLStart := "htm/chapters.htm",
   PDFFile   := "doc/manual.pdf",
@@ -52,18 +56,14 @@ PackageDoc := rec(
   Autoload  := true
 ),
 
-
 Dependencies := rec(
-   GAP := ">=4.4",
+  GAP := ">=4.8",
   NeededOtherPackages := [],
   SuggestedOtherPackages := [],
   ExternalConditions := []
 ),
 
 AvailabilityTest := ReturnTrue,
-BannerString := Concatenation( 
-  "--\nRiG, A GAP package for racks, Version ", ~.Version, "\n", ~.ArchiveURL,"\n"),
-Autoload := false,
 TestFile := "tst/testall.g",
 Keywords := ["racks", "quandles", "nichols algebras", "knots"]
 ));

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Cite as
 -------
 If you have used Rig in the preparation of a paper please cite it as:
 
-L. Vendramin. Rig, a GAP package for racks, quandles and Nichols algebras. Available at http://github.com/vendramin/rig/
+L. Vendramin. Rig, a GAP package for racks, quandles and Nichols algebras. Available at https://github.com/gap-packages/rig/
 
 Contributions
 -------------

--- a/doc/introduction.tex
+++ b/doc/introduction.tex
@@ -14,9 +14,12 @@ To load the package, type:
 
 \beginexample
 gap> LoadPackage("rig");
---
-RiG, A GAP package for racks, Version 0.9
-http://code.google.com/p/rig/
+-------------------------------------------------------------------
+Loading  rig 1 (A GAP package for racks, quandles and crossed sets)
+by Leandro Vendramin (http://mate.dm.uba.ar/~lvendram).
+Homepage: https://gap-packages.github.io/rig/
+Report issues at https://github.com/gap-packages/rig/issues
+-------------------------------------------------------------------
 true
 \endexample
 


### PR DESCRIPTION
I also took the liberty of setting up a `gh-pages` branch based on the changes in this, using <https://github.com/gap-system/GitHubPagesForGAP>. This produces a package homepage: <https://gap-packages.github.io/rig/>

This PR also prepares everything for using <https://github.com/gap-system/ReleaseTools>, so new releases should be relatively easy to make in the future.